### PR TITLE
Feature: add multi-store support and fix PS9 double index.php routing…

### DIFF
--- a/App/Helper/Data.php
+++ b/App/Helper/Data.php
@@ -33,6 +33,7 @@ if (!defined('_PS_VERSION_')) {
 class Data
 {
     private static $init;
+    private static $initShopId;
 
     private static $data;
 
@@ -50,7 +51,9 @@ class Data
 
     public static function init()
     {
-        if (self::$init == null) {
+        $currentShopId = \Mktr\Model\Config::shop();
+        if (self::$init == null || self::$initShopId !== $currentShopId) {
+            self::$initShopId = $currentShopId;
             self::$init = new self();
         }
 
@@ -111,9 +114,15 @@ class Data
             throw new \Exception('Filename cannot be empty.');
         }
 
-        $fullPath = MKTR_APP . 'Storage/' . $fName;
+        $storagePath = MKTR_APP . \Mktr\Model\Config::getStoragePath();
 
-        $realBase = realpath(MKTR_APP . 'Storage/');
+        if (!is_dir($storagePath)) {
+            @mkdir($storagePath, 0755, true);
+        }
+
+        $fullPath = $storagePath . $fName;
+
+        $realBase = realpath($storagePath);
         $realPath = realpath(dirname($fullPath));
 
         if ($realPath === false || strpos($realPath, $realBase) !== 0) {

--- a/App/Helper/FileSystem.php
+++ b/App/Helper/FileSystem.php
@@ -52,7 +52,14 @@ class FileSystem
     public static function setWorkDirectory($name = 'Storage')
     {
         if ($name != 'base' && !self::$useRoot) {
-            self::$path = MKTR_APP . $name . '/';
+            if ($name === 'Storage' || $name === 'Storage/') {
+                self::$path = MKTR_APP . \Mktr\Model\Config::getStoragePath();
+            } else {
+                self::$path = MKTR_APP . $name . '/';
+            }
+            if (!is_dir(self::$path)) {
+                @mkdir(self::$path, 0755, true);
+            }
         } else {
             self::$path = MKTR_ROOT;
         }
@@ -152,6 +159,11 @@ class FileSystem
         }
 
         return self::$path;
+    }
+
+    public static function resetPath()
+    {
+        self::$path = null;
     }
 
     /** @noinspection PhpUnused */

--- a/App/Helper/Setup.php
+++ b/App/Helper/Setup.php
@@ -35,15 +35,15 @@ class Setup
     const TABS = [
         'Mktr' => [
             'name' => 'TheMarketer',
-            'ico' => null,
+            'ico' => '',
         ],
         'MktrTracker' => [
             'name' => 'TheMarketer - Tracker',
-            'ico' => 'mktr',
+            'ico' => '',
         ],
         'MktrGoogle' => [
             'name' => 'TheMarketer - Google',
-            'ico' => 'mktr',
+            'ico' => '',
         ],
     ];
 
@@ -67,8 +67,8 @@ class Setup
                 $tab->name[$lang] = $value['name'];
                 if (_PS_VERSION_ >= 1.7) {
                     $tab->icon = $value['ico'];
-                    $tab->wording = 'Mktr';
-                    $tab->wording_domain = 'Admin.Navigation.Menu';
+                    $tab->wording = $value['name'];
+                    $tab->wording_domain = 'Modules.Mktr.Admin';
                 }
                 if ($key !== 'Mktr' && $parent === null) {
                     $parent = self::getTabId('Mktr');
@@ -100,6 +100,8 @@ class Setup
 
         self::AddTabs();
 
+        self::ensureStorageDirectories();
+
         \Mktr\Model\Config::AddDefault();
 
         $data = \Mktr\Model\Config::nws();
@@ -107,6 +109,28 @@ class Setup
         \Mktr\Model\Config::setConfig('MKTR_TRACKER_CONFIRMATION', \Mktr\Model\Config::getConfig($data['CONFIRMATION']));
         /* @phpstan-ignore-next-line */
         \Mktr\Model\Config::setConfig('MKTR_TRACKER_NOTIFICATION', \Mktr\Model\Config::getConfig($data['NOTIFICATION']));
+    }
+
+    public static function ensureStorageDirectories()
+    {
+        $baseStorage = MKTR_APP . 'Storage/';
+        if (!is_dir($baseStorage)) {
+            @mkdir($baseStorage, 0755, true);
+        }
+
+        if (\Shop::isFeatureActive()) {
+            $shops = \Shop::getShops(true, null, true);
+            foreach ($shops as $shopId) {
+                $shopDir = $baseStorage . (int) $shopId . '/';
+                if (!is_dir($shopDir)) {
+                    @mkdir($shopDir, 0755, true);
+                }
+
+                if (!file_exists($shopDir . 'index.php')) {
+                    @file_put_contents($shopDir . 'index.php', "<?php\nheader('Expires: Mon, 26 Jul 1997 05:00:00 GMT');\nheader('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');\n\nheader('Cache-Control: no-store, no-cache, must-revalidate');\nheader('Cache-Control: post-check=0, pre-check=0', false);\nheader('Pragma: no-cache');\n\nheader('Location: ../../../');\nexit;\n");
+                }
+            }
+        }
     }
 
     public static function uninstall()
@@ -129,6 +153,9 @@ class Setup
             }
         }
 
+        self::cleanStorageDirectories();
+        self::cleanJsFiles();
+
         $data = \Mktr\Model\Config::nws();
         /* @phpstan-ignore-next-line */
         \Mktr\Model\Config::setConfig($data['CONFIRMATION'], \Mktr\Model\Config::getConfig('MKTR_TRACKER_CONFIRMATION'));
@@ -137,5 +164,38 @@ class Setup
 
         /* must be after MKTR_TRACKER_CONFIRMATION And MKTR_TRACKER_NOTIFICATION * */
         \Mktr\Model\Config::delete();
+    }
+
+    private static function cleanStorageDirectories()
+    {
+        $baseStorage = MKTR_APP . 'Storage/';
+        if (is_dir($baseStorage)) {
+            $dirs = glob($baseStorage . '[0-9]*', GLOB_ONLYDIR);
+            if ($dirs) {
+                foreach ($dirs as $dir) {
+                    $files = glob($dir . '/*');
+                    if ($files) {
+                        foreach ($files as $file) {
+                            if (is_file($file)) {
+                                @unlink($file);
+                            }
+                        }
+                    }
+                    @rmdir($dir);
+                }
+            }
+        }
+    }
+
+    private static function cleanJsFiles()
+    {
+        $jsFiles = glob(MKTR_APP . 'mktr.*.js');
+        if ($jsFiles) {
+            foreach ($jsFiles as $file) {
+                if (is_file($file)) {
+                    @unlink($file);
+                }
+            }
+        }
     }
 }

--- a/App/Model/Config.php
+++ b/App/Model/Config.php
@@ -122,6 +122,7 @@ class Config
     public static $dateFormatParam = 'Y-m-d';
 
     private static $i;
+    private static $instances = [];
     private static $nws;
     private static $lang_id;
     private static $context;
@@ -178,14 +179,30 @@ class Config
 
     public static function i($new = false)
     {
-        if (self::$i === null || $new === true) {
+        $shopId = self::shop();
+        if ($new === true || !isset(self::$instances[$shopId])) {
             self::CFG();
             $class = get_called_class();
-            self::$i = new $class();
-            // self::$i = new static();
+            self::$instances[$shopId] = new $class();
         }
 
+        self::$i = self::$instances[$shopId];
+
         return self::$i;
+    }
+
+    public static function reset()
+    {
+        self::$i = null;
+        self::$instances = [];
+        self::$shop = null;
+        self::$lang_id = null;
+        self::$checkData = [
+            'showJs' => null,
+            'showJsOut' => null,
+            'showGoogle' => null,
+            'rest' => null,
+        ];
     }
 
     public static function CFG()
@@ -260,7 +277,7 @@ class Config
         }
 
         if ($this->attributes[$name] === null) {
-            $this->attributes[$name] = \Configuration::get(self::$CFG_DATA[$name]['key']);
+            $this->attributes[$name] = self::getShopConfigValue(self::$CFG_DATA[$name]['key']);
             if (!in_array(self::$CFG_DATA[$name]['type'], ['bool', 'boolean']) && $this->attributes[$name] === false) {
                 $this->attributes[$name] = self::$CFG_DATA[$name]['default'];
             } else {
@@ -282,7 +299,7 @@ class Config
     protected function getConfig($name)
     {
         if (!array_key_exists($name, $this->attributes) || $this->attributes[$name] === null) {
-            $this->attributes[$name] = \Configuration::get($name);
+            $this->attributes[$name] = self::getShopConfigValue($name);
         }
 
         return $this->attributes[$name];
@@ -290,7 +307,7 @@ class Config
 
     protected function setConfig($name, $value)
     {
-        \Configuration::updateValue($name, $value);
+        self::updateShopConfigValue($name, $value);
         $this->attributes[$name] = $value;
 
         return $this->attributes[$name];
@@ -384,15 +401,38 @@ class Config
 
     public static function AddDefault()
     {
-        $i = self::i();
+        if (\Shop::isFeatureActive()) {
+            self::AddDefaultForAllShops();
+        } else {
+            $i = self::i();
+            self::CFG();
+            foreach (self::$CFG_DATA as $key => $v) {
+                if (preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $key)) {
+                    $i->{$key} = $v['default'];
+                }
+            }
+
+            $i->save();
+        }
+    }
+
+    public static function AddDefaultForAllShops()
+    {
         self::CFG();
-        foreach (self::$CFG_DATA as $key => $v) {
-            if (preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $key)) {
-                $i->{$key} = $v['default'];
+        $shops = \Shop::getShops(true, null, true);
+        foreach ($shops as $shopId) {
+            foreach (self::$CFG_DATA as $key => $v) {
+                if (preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $key)) {
+                    $val = $v['default'];
+                    if (in_array($v['type'], ['array', 'object'])) {
+                        $val = call_user_func('serialize', $val);
+                    } elseif (in_array($v['type'], ['bool', 'boolean'])) {
+                        $val = (int) $val;
+                    }
+                    \Configuration::updateValue($v['key'], $val, false, null, (int) $shopId);
+                }
             }
         }
-
-        $i->save();
     }
 
     public static function showJs($new = false)
@@ -481,11 +521,9 @@ class Config
             foreach ($this->load as $key => $value) {
                 $value1 = $this->attributes[$key];
                 if ($value1 !== null) {
-                    \Configuration::updateValue(self::$CFG_DATA[$key]['key'], $this->unCast($key, $value1), true);
-                // if (in_array($key, ['brand', 'color', 'size'])) { var_dump($key, $value1,$this->unCast($key, $value1), \Configuration::updateValue(self::$CFG_DATA[$key]['key'], $this->unCast($key, $value1), true));die(); }
-                // var_dump(self::$CFG_DATA[$key]['key'], $key, $value1); die();
+                    self::updateShopConfigValue(self::$CFG_DATA[$key]['key'], $this->unCast($key, $value1), true);
                 } else {
-                    \Configuration::updateValue(self::$CFG_DATA[$key]['key'], null);
+                    self::updateShopConfigValue(self::$CFG_DATA[$key]['key'], null);
                 }
             }
         }
@@ -549,5 +587,70 @@ class Config
             default:
                 return $value;
         }
+    }
+
+    /**
+     * @param string $configKey
+     * @param int|null $idLang
+     * @return bool|string|null
+     */
+    public static function getShopConfigValue($configKey, $idLang = null)
+    {
+        if (!\Shop::isFeatureActive()) {
+            return \Configuration::get($configKey, $idLang);
+        }
+
+        $shopId = self::shop();
+        if ($shopId) {
+            return \Configuration::get($configKey, $idLang, null, $shopId);
+        }
+
+        return \Configuration::get($configKey, $idLang);
+    }
+
+    /**
+     * @param string $configKey
+     * @param mixed $value
+     * @param bool $html
+     * @return bool
+     */
+    public static function updateShopConfigValue($configKey, $value, $html = false)
+    {
+        if (!\Shop::isFeatureActive()) {
+            return \Configuration::updateValue($configKey, $value, $html);
+        }
+
+        $shopId = self::shop();
+        if ($shopId) {
+            return \Configuration::updateValue($configKey, $value, $html, null, $shopId);
+        }
+
+        return \Configuration::updateValue($configKey, $value, $html);
+    }
+
+    /**
+     * @return string
+     */
+    public static function getStoragePath()
+    {
+        if (\Shop::isFeatureActive()) {
+            $shopId = self::shop();
+            return 'Storage/' . (int) $shopId . '/';
+        }
+
+        return 'Storage/';
+    }
+
+    /**
+     * @return string
+     */
+    public static function getJsPrefix()
+    {
+        if (\Shop::isFeatureActive()) {
+            $shopId = self::shop();
+            return 'mktr.' . (int) $shopId . '.';
+        }
+
+        return 'mktr.';
     }
 }

--- a/App/Model/Orders.php
+++ b/App/Model/Orders.php
@@ -182,16 +182,22 @@ class Orders extends DataBase
         $sql = 'SELECT `id_order`' .
                 ' FROM `' . _DB_PREFIX_ . 'orders`';
 
-        if ($start_date !== null || $end_date !== null) {
-            $wh = [];
-            if ($start_date !== null) {
-                $wh[] = " date_add >= '" . \pSQL($start_date) . "'";
-            }
+        $wh = [];
 
-            if ($end_date !== null) {
-                $wh[] = " date_add <= '" . \pSQL($end_date) . "'";
-            }
-            $sql .= ' WHERE' . implode('AND', $wh);
+        if (\Shop::isFeatureActive()) {
+            $wh[] = ' `id_shop` = ' . (int) Config::shop();
+        }
+
+        if ($start_date !== null) {
+            $wh[] = " date_add >= '" . \pSQL($start_date) . "'";
+        }
+
+        if ($end_date !== null) {
+            $wh[] = " date_add <= '" . \pSQL($end_date) . "'";
+        }
+
+        if (!empty($wh)) {
+            $sql .= ' WHERE' . implode(' AND', $wh);
         }
         $sql .= ' ORDER BY `' . $i->orderBy . '` ' . $i->direction . ' LIMIT ' . $start . ', ' . $limit;
 

--- a/App/Model/Product.php
+++ b/App/Model/Product.php
@@ -334,8 +334,13 @@ class Product extends DataBase
         if ($this->isCombination === null) {
             if (_PS_VERSION_ < '1.7.8.0') {
                 $this->isCombination = $this->data->hasAttributes();
+
+                if (!$this->isCombination) {
+                    $combinations = $this->data->getAttributeCombinations(Config::getLang());
+                    $this->isCombination = !empty($combinations);
+                }
             } else {
-                $this->isCombination = $this->data->product_type === 'combinations';
+                $this->isCombination = $this->data->product_type === 'combinations' || $this->data->hasAttributes();
             }
         }
 

--- a/App/Route/refreshJS.php
+++ b/App/Route/refreshJS.php
@@ -30,6 +30,10 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+if (class_exists('Mktr\\Route\\refreshJS', false)) {
+    return;
+}
+
 class refreshJS
 {
     const FIREBASE_CONFIG = 'const firebaseConfig = {
@@ -63,6 +67,11 @@ importScripts("https://t.themarketer.com/firebase.js");';
         }
 
         return self::$config;
+    }
+
+    public static function resetConfig()
+    {
+        self::$config = null;
     }
 
     public static function loadJs()
@@ -381,14 +390,18 @@ window.mktr.ready = true;
 }
 ';
 
-            if (self::c()->js_file !== '' && file_exists(MKTR_APP . 'mktr.' . self::c()->js_file . '.js')) {
-                unlink(MKTR_APP . 'mktr.' . self::c()->js_file . '.js');
+            $jsPrefix = \Mktr\Model\Config::getJsPrefix();
+
+            if (self::c()->js_file !== '' && file_exists(MKTR_APP . $jsPrefix . self::c()->js_file . '.js')) {
+                unlink(MKTR_APP . $jsPrefix . self::c()->js_file . '.js');
             }
             self::c()->js_file = time();
-            self::write('mktr.' . self::c()->js_file . '.js', $c);
+            self::write($jsPrefix . self::c()->js_file . '.js', $c);
         } else {
-            if (self::c()->js_file !== '' && file_exists(MKTR_APP . 'mktr.' . self::c()->js_file . '.js')) {
-                unlink(MKTR_APP . 'mktr.' . self::c()->js_file . '.js');
+            $jsPrefix = \Mktr\Model\Config::getJsPrefix();
+
+            if (self::c()->js_file !== '' && file_exists(MKTR_APP . $jsPrefix . self::c()->js_file . '.js')) {
+                unlink(MKTR_APP . $jsPrefix . self::c()->js_file . '.js');
             }
             self::c()->js_file = '';
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img style="height:35px;vertical-align: middle;" src="https://github.com/the-marketer/Prestashop/blob/latest/logo.png" alt="TheMarketer"> TheMarketer - Prestashop Module
 
 ## Compatible with:
+    - Prestashop 9 Module
     - Prestashop 8 Module
     - Prestashop 1.7 Module
     - Prestashop 1.6 Module

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>mktr</name>
 	<displayName><![CDATA[TheMarketer]]></displayName>
-	<version><![CDATA[1.1.4]]></version>
+	<version><![CDATA[1.1.5]]></version>
 	<description><![CDATA[TheMarketer - PrestaShop Version]]></description>
 	<author><![CDATA[TheMarketer.com]]></author>
 	<tab><![CDATA[advertising_marketing]]></tab>

--- a/controllers/admin/MktrController.php
+++ b/controllers/admin/MktrController.php
@@ -52,6 +52,7 @@ class MktrController extends \AdminController
     private static $t;
     private static $config;
     private static $jsRefresh = true;
+    private static $baseIndex = null;
 
     private static $err = [
         'log' => [],
@@ -64,6 +65,9 @@ class MktrController extends \AdminController
 
     public function __construct()
     {
+        $this->multishop_context = \Shop::CONTEXT_SHOP | \Shop::CONTEXT_GROUP | \Shop::CONTEXT_ALL;
+        $this->multishop_context_group = true;
+
         parent::__construct();
         self::$i = $this;
 
@@ -136,7 +140,7 @@ class MktrController extends \AdminController
         $p = (self::$page === 'tracker' ? 'google' : 'tracker');
 
         $this->page_header_toolbar_btn['settings'] = [
-            'href' => self::$currentIndex . '&page=' . $p . '&' . $this->token(),
+            'href' => $this->getBaseIndex() . '&page=' . $p . '&' . $this->token(),
             'desc' => ucfirst($p) . ' Settings',
             'icon' => 'process-icon-cogs',
         ];
@@ -316,6 +320,7 @@ class MktrController extends \AdminController
             }
         }
 
+        \Mktr\Route\refreshJS::resetConfig();
         \Mktr\Route\refreshJS::loadJs();
 
         self::$config->save();
@@ -347,7 +352,7 @@ class MktrController extends \AdminController
         $helper->identifier = $this->identifier;
         $helper->submit_action = 'submitMktrModule';
         $helper->token = $this->token;
-        $helper->currentIndex = self::$currentIndex . '&page=' . self::$page;
+        $helper->currentIndex = $this->getBaseIndex() . '&page=' . self::$page;
         $values = $this->getConfigFormValues();
         $values['dni'] = 0;
         $values['first_call'] = false;
@@ -393,8 +398,26 @@ class MktrController extends \AdminController
         return self::$t;
     }
 
+    private function getBaseIndex()
+    {
+        if (self::$baseIndex === null) {
+            if (version_compare(_PS_VERSION_, '9.0.0', '>=')) {
+                $link = $this->context->link->getAdminLink('Mktr', false);
+                if (strpos($link, 'http') !== 0 && strpos($link, '/') !== 0) {
+                    $link = __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/' . $link;
+                }
+                self::$baseIndex = $link;
+            } else {
+                self::$baseIndex = self::$currentIndex;
+            }
+        }
+
+        return self::$baseIndex;
+    }
+
     public function initContent()
     {
+        \Mktr\Model\Config::reset();
         /* @phpstan-ignore-next-line */
         self::$config = \Mktr\Model\Config::setLang($this->context->language->id);
 
@@ -411,6 +434,31 @@ class MktrController extends \AdminController
         $this->title = 'TheMarketer - ' . ucfirst(self::$page);
         $this->toolbar_btn = $this->getToolbarBtn();
         $this->show_page_header_toolbar = true;
+
+        $multiStoreHeader = '';
+        if (\Shop::isFeatureActive()) {
+            $shopContext = \Shop::getContext();
+            if ($shopContext === \Shop::CONTEXT_ALL) {
+                $multiStoreHeader = '<div class="alert alert-info"><i class="icon icon-info-circle"></i> ' .
+                    'You are editing settings for <strong>All shops</strong>. Changes will apply to all shops that don\'t have specific values set.' .
+                    '</div>';
+            } elseif ($shopContext === \Shop::CONTEXT_GROUP) {
+                $groupName = '';
+                if (method_exists($this->context->shop, 'getGroup')) {
+                    $group = $this->context->shop->getGroup();
+                    $groupName = is_object($group) ? $group->name : '';
+                }
+                $multiStoreHeader = '<div class="alert alert-info"><i class="icon icon-info-circle"></i> ' .
+                    'You are editing settings for shop group: <strong>' . $groupName . '</strong>.' .
+                    '</div>';
+            } else {
+                $shopName = isset($this->context->shop->name) ? $this->context->shop->name : 'Current shop';
+                $multiStoreHeader = '<div class="alert alert-info"><i class="icon icon-info-circle"></i> ' .
+                    'You are editing settings for shop: <strong>' . $shopName . '</strong>.' .
+                    '</div>';
+            }
+        }
+
         $this->context->smarty->assign(
             [
                 'toolbar_scroll' => true,
@@ -427,7 +475,7 @@ class MktrController extends \AdminController
                     ],
                     'tab' => [
                         'name' => 'TheMarketer',
-                        'href' => self::$currentIndex . '&' . $this->token(),
+                        'href' => $this->getBaseIndex() . '&' . $this->token(),
                         'icon' => '',
                         'id_parent' => 0,
                     ],
@@ -438,7 +486,7 @@ class MktrController extends \AdminController
                         'id_parent' => 0,
                     ],
                 ],
-                'content' => $this->outPut(),
+                'content' => $multiStoreHeader . $this->outPut(),
                 'title' => $this->title,
                 'toolbar_btn' => $this->toolbar_btn,
                 'page_header_toolbar_btn' => $this->toolbar_btn,

--- a/controllers/front/Api.php
+++ b/controllers/front/Api.php
@@ -192,7 +192,7 @@ class MktrApiModuleFrontController extends \FrontController
                     );
                 }
 
-                FileSystem::setWorkDirectory('Storage/');
+                FileSystem::setWorkDirectory(\Mktr\Model\Config::getStoragePath());
 
                 if ($read !== null && $isStatic && FileSystem::fileExists($fileName)) {
                     Valid::Output(FileSystem::readFile($fileName), null, null, true);

--- a/controllers/front/Cron.php
+++ b/controllers/front/Cron.php
@@ -33,6 +33,8 @@ class MktrCronModuleFrontController extends \ModuleFrontController
     {
         parent::initContent();
 
+        \Mktr\Helper\FileSystem::resetPath();
+
         $module = new \Mktr();
         if (\Mktr\Model\Config::showJS()) {
             $data = \Mktr\Helper\Data::init();

--- a/mktr.php
+++ b/mktr.php
@@ -64,7 +64,7 @@ class Mktr extends \Module
     {
         $this->name = 'mktr';
         $this->tab = 'advertising_marketing';
-        $this->version = '1.1.4';
+        $this->version = '1.1.5';
         $this->author = 'TheMarketer.com';
         $this->need_instance = 1;
         $this->bootstrap = true;
@@ -155,6 +155,7 @@ class Mktr extends \Module
         if (self::$update) {
             if (file_exists(MKTR_APP . 'mktr.php')) {
                 self::$update = false;
+                \Mktr\Route\refreshJS::resetConfig();
                 \Mktr\Route\refreshJS::loadJs();
 
                 self::correctUpdate(
@@ -201,6 +202,10 @@ class Mktr extends \Module
 
     public function install()
     {
+        if (\Shop::isFeatureActive()) {
+            \Shop::setContext(\Shop::CONTEXT_ALL);
+        }
+
         if (_PS_VERSION_ >= 1.6) {
             $hook = [
                 /* Front */
@@ -295,6 +300,10 @@ class Mktr extends \Module
 
     public function uninstall()
     {
+        if (\Shop::isFeatureActive()) {
+            \Shop::setContext(\Shop::CONTEXT_ALL);
+        }
+
         \Mktr\Helper\Setup::uninstall();
 
         if (parent::uninstall()) {
@@ -630,7 +639,8 @@ class Mktr extends \Module
                     \Mktr\Helper\Session::save();
                 }
 
-                $this->context->controller->addJS($this->_path . 'mktr.' . $js . '.js');
+                $jsPrefix = \Mktr\Model\Config::getJsPrefix();
+                $this->context->controller->addJS($this->_path . $jsPrefix . $js . '.js');
             }
         }
     }

--- a/views/css/back.css
+++ b/views/css/back.css
@@ -7,57 +7,38 @@
  * @docs        https://themarketer.com/resources/api
  **/
 
- .icon-Mktr:before{
-    content:"Ⓜ️";
-    height: 0.5rem;
-    display: block;
+.icon-Mktr:before {
+    content: "\e80b";
+    font-family: "Material Icons", Arial, sans-serif;
+    font-size: 14px;
+    display: inline-block;
+    vertical-align: middle;
 }
 
-.mi-mktr:before{
-    content:"Ⓜ️";
-    height: 0.2rem;
-    display: block;
+.process-icon-mktr-up:before {
+    content: "";
 }
 
-.sidebar-closed .mi-mktr:before{
-    content:"Ⓜ️";
-    height: 0.5rem;
-    display: block; 
+.process-icon-mktr-user:before {
+    content: "";
 }
 
-.process-icon-mktr-up:before{
-    content:""
+.main-menu .link-levelone img[src*="mktr/logo"],
+.main-menu .link-leveltwo img[src*="mktr/logo"],
+nav.nav-bar img[src*="mktr/logo"],
+#nav-sidebar img[src*="mktr/logo"],
+.sidebar img[src*="mktr/logo"] {
+    max-width: 20px !important;
+    max-height: 20px !important;
+    width: 20px !important;
+    height: auto !important;
+    object-fit: contain;
 }
-.process-icon-mktr-user:before{content:""}
 
 .mi-mktr {
-    -webkit-text-size-adjust: 100%;
-    -webkit-tap-highlight-color: rgba(0,0,0,0);
-    --breakpoint-xs: 0;
-    --breakpoint-sm: 544px;
-    --breakpoint-md: 768px;
-    --breakpoint-lg: 1024px;
-    --breakpoint-xl: 1300px;
-    --breakpoint-xxl: 1600px;
-    --font-family-sans-serif: "Open Sans", helvetica, arial, sans-serif;
-    --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    word-break: break-word;
-    box-sizing: border-box;
-    display: inline-block;
-    font-family: "Material Icons", Arial, Verdana, Tahoma, sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: normal;
-    white-space: nowrap;
-    vertical-align: middle;
-    direction: ltr;
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
-    font-feature-settings: "liga";
-    font-size: 1.188rem;
-    line-height: inherit;
-    color: #fff;
-    width: 19px;
+    font-size: 0 !important;
+    width: 0 !important;
+    height: 0 !important;
+    display: none !important;
+    overflow: hidden;
 }


### PR DESCRIPTION
… issue

- Fix NotFoundHttpException caused by double index.php in form action URL on PS9
- Make getBaseIndex() compatible with PrestaShop 1.6 through 9.x using version_compare()
- Add multi-store context header in admin panel (shop/group selector awareness)
- Use Shop::getContext() static call for PS 1.6 compatibility
- Add method_exists checks for getGroup() to support older PS versions
- Ensure form action URLs are absolute to prevent browser relative URL resolution issues